### PR TITLE
Added DataHub

### DIFF
--- a/data/nodes.ts
+++ b/data/nodes.ts
@@ -154,6 +154,14 @@ const nodes: Node[] = [
     status: true,
     secret: true,
   },
+  {
+    name: 'DataHub',
+    price: 'Freemium',
+    endpoint: `https://ethereum-mainnet--rpc.datahub.figment.io/apikey/${process.env.DATAHUB_API_KEY}`,
+    website: 'https://datahub.figment.io/',
+    status: true,
+    secret: true,
+  },
 ];
 
 function finish(start: number, endpoint: string) {


### PR DESCRIPTION
Hey @dmihal 
I recently came across https://ethereumnodes.com/ which is really cool & helpful for devs. I appreciate the work & your efforts. While looking at the service providers I found DataHub by Figment which is one of the Ethereum node providers wasn't listed on the site so I just added it and made a PR. Let me know if you have any questions about that.
Also, DataHub offers nodes across 15+ protocols you can read more about it **[HERE](https://datahub.figment.io)** TIA :)