### PR TITLE
Fixing a small issue in displaying response time for non-responsive endpoint

### DIFF
--- a/data/nodes.ts
+++ b/data/nodes.ts
@@ -204,16 +204,25 @@ async function checkNodeStatus(endpoint: string, authentication?: string | null)
   }
 
   try {
-    const result = await fetch(endpoint, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({
-        id: "1",
-        jsonrpc: "2.0",
-        method: "eth_blockNumber",
-        params: [],
-      }),
-    });
+    var result
+    try{
+      result = await fetch(endpoint, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          id: "1",
+          jsonrpc: "2.0",
+          method: "eth_blockNumber",
+          params: [],
+        }),
+      })
+    }catch(err) {
+      return {
+        status: false,
+        loadTime: -1,
+      };
+    };
+    
     if (result.status !== 200) {
       console.log(endpoint, 'failed')
       console.log(await result.text());


### PR DESCRIPTION
<img width="1244" alt="Screenshot 2022-07-13 at 12 32 10" src="https://user-images.githubusercontent.com/19160757/178652558-7d5a818f-92bc-45b5-a863-021058efe927.png">

Fixing a small issue for non-responsive endpoints.
Currently non-responsive nodes are labeled as "Down" but still has a load-time. 
